### PR TITLE
Build on Linux as on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To run PCHAIN Wallet in development you need:
 - [Yarn](https://yarnpkg.com/) package manager
 
 
-### Initialization
+### Installation
 
 Now you're ready to initialize PCHAIN Wallet for development:
 
@@ -16,8 +16,16 @@ Now you're ready to initialize PCHAIN Wallet for development:
 $ git clone https://github.com/pchain-org/wallet.git
 $ cd wallet
 $ yarn
-$ yarn build:mac  #mac
-$ yarn build:win   #windows
+```
+
+### Post-installation
+
+To build libraries for your specific platform, use one of the following flags:
+
+```bash
+$ yarn build:linux #for Linux
+$ yarn build:mac   #for Mac
+$ yarn build:win   #for Windows
 ```
 
 ### Run PCHAIN Wallet
@@ -26,14 +34,14 @@ $ yarn build:win   #windows
 $ yarn start
 ```
 
-
 ### Generate packages
 
-To build binaries for specific platforms, use the following flags:
+To build binaries for your specific platform, use one of the following flags:
 
 ```bash
-$ yarn packager:mac  #mac
-$ yarn packager:win  #windows
+$ yarn packager:linux #for Linux
+$ yarn packager:mac   #for Mac
+$ yarn packager:win   #for Windows
 ```
 
 ### Config folder

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
+    "build:linux": "./node_modules/.bin/electron-rebuild",
     "build:mac": "./node_modules/.bin/electron-rebuild",
     "build:win": ".\\node_modules\\.bin\\electron-rebuild.cmd",
     "packager:mac": "electron-packager ./ PIWallet --platform=darwin --out ./app --app-version 1.0.2 --overwrite --icon=public/img/logo.hqx ",
     "packager:win": "electron-packager ./ PIWallet --platform=win32 --arch=x64 --architecture=x86 --out=./app --asar --app-version 1.0.2 --overwrite --icon=public/img/logo.ico",
-    "packager:liunx": "electron-packager ./ PIWallet --platform=linux --arch=x64 --out=./app --asar --app-version 1.0.2 --overwrite"
+    "packager:linux": "electron-packager ./ PIWallet --platform=linux --arch=x64 --out=./app --asar --app-version 1.0.2 --overwrite"
   },
   "keywords": [
     "pchain wallet"


### PR DESCRIPTION
I have corrected the packaging method for Linux and I have added the build method for Linux which is the same than for Mac.
I have tested it and here is the output :
```
bjuglas@bjuglas1883:~/Documents/Pchain/wallet$ yarn build:linux
yarn run v1.15.2
$ ./node_modules/.bin/electron-rebuild
✔ Rebuild Complete
Done in 79.44s.
bjuglas@bjuglas1883:~/Documents/Pchain/wallet$ yarn packager:linux
yarn run v1.15.2
$ electron-packager ./ PIWallet --platform=linux --arch=x64 --out=./app --asar --app-version 1.0.2 --overwrite
Packaging app for platform linux x64 using electron v3.0.0
Wrote new app to app/PIWallet-linux-x64
Done in 6.03s.
```
It worked well for me and I have managed to import my MetaMask account in my Pchain wallet.